### PR TITLE
remove db-data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,7 @@ app/googleAccount.txt
 Account_static/
 
 # DB
-db-data/*
-!db-data/.gitkeep
-db-init/*
+db-data
 
 # SSL 테스트용
 app/stunnel/*


### PR DESCRIPTION
Turns out docker creates directory for mounted volume if it doesn't exist.
Since db data is not commited and the directory was commited only for
structuring purpose anyways, the directory can be removed.